### PR TITLE
Update color-and-contrast.md

### DIFF
--- a/pages/visual-design/color-and-contrast.md
+++ b/pages/visual-design/color-and-contrast.md
@@ -15,7 +15,7 @@ personas:
   - Measure the contrast between text and backgound colors with tools like [WebAIM's Color Contrast Checker](http://webaim.org/resources/contrastchecker/) or a [Sketch plugin](https://github.com/getflourish/Sketch-Color-Contrast-Analyser).
 - Exceptions:
   - Color contrast ratio requirements apply to text and graphics that are essential for understanding the content or functionality. You don’t need to meet color contrast requirements for logos or incidental graphic elements.
-  - Text that is part of a disabled control states or disabled buttons does not need to meet the minimum contrast ratio.
+  - Text that is part of a disabled control's state or disabled buttons does not need to meet the minimum contrast ratio.
   - Text that is part of a logo has no minimum contrast requirement.
 - Slightly temper the contrast between your text and background color. For example: don’t use pure black text on a pure white background. Stark contrast can result in blurred or moving text for people with Irlen syndrome.
 - To use text over images, add a solid background behind the text or a dark overlay to the image.


### PR DESCRIPTION
I thought there may be a typo, and added a possessive apostrophe to control. 'Text that is part of a disabled control's state or disabled buttons does not need to meet the minimum contrast ratio.'

I think it can also be written: 'Text that is part of disabled control states or disabled buttons does not need to meet the minimum contrast ratio.'