### PR TITLE
add full URLs to canonical & og links in doc head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,8 +16,8 @@
   <meta property="og:image" content="https://accessibility.digital.gov/assets/img/a11y-icon.png">
   <meta name="twitter:card" content="summary">
 
-  <link rel="canonical" href="https://accessibility.digital.gov">
-  <meta property="og:url" content="https://accessibility.digital.gov">
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
 
   <link rel="stylesheet" href="{{ "/assets/fonts/font-awesome.min.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/stylesheets/site/main.css" | relative_url }}">


### PR DESCRIPTION
Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>