### PR TITLE
Updated accessibility statement to be in sync with uswds 3.5.0

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,8 +36,8 @@
             </li>
 
             <li class="usa-identifier__required-links-item">
-              <a href="https://www.gsa.gov/website-information/accessibility-aids" class="usa-identifier__required-link usa-link">
-                Accessibility support
+              <a href="https://www.gsa.gov/website-information/accessibility-statement" class="usa-identifier__required-link usa-link">
+                Accessibility statement
               </a>
             </li>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
-
   {% include head.html %}
 
   <body class="page-{{ page.title | slugify }} page-{{ page.layout }}">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,6 @@
 layout: default
 ---
 <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
-
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title | escape }}</h1>
     <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>

--- a/_layouts/primary.html
+++ b/_layouts/primary.html
@@ -3,6 +3,7 @@ layout: default
 ---
 
   <!-- Sidebar navigation -->
+  
   <div class="grid-row">
     <aside class="grid-col-12 tablet:grid-col-4 sidenav sticky">
       <ul class="usa-sidenav">


### PR DESCRIPTION
## Summary
Updated `usa-identifier` to match [uswds 3.5.0](https://designsystem.digital.gov/components/identifier/)

## Solution

- Rename `Accessibility support` to `Accessibility statement`
- Updated url from `https://www.gsa.gov/website-information/accessibility-aids` to `https://www.gsa.gov/website-information/accessibility-statement`

## Preview

- [Preview](https://federalist-ed9ac7ce-8870-4699-95f8-e85f8b3c15b8.sites.pages.cloud.gov/preview/gsa/accessibility-for-teams/nl-update-identifier-a11y-statement/)