### PR TITLE
Poam Nov 23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@uswds/uswds": "3.4.1"
+        "@uswds/uswds": "3.7.0"
       },
       "devDependencies": {
         "@uswds/compile": "^1.0.0",
@@ -222,11 +222,11 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
-      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.0.tgz",
+      "integrity": "sha512-8mjiP0x0tE5JC7YTuF7WIXkC0pmTVQPzP2CfYE8GHDLdDCnEVUCNjTSljKTqEGxsQuP5JXgNpt99H7pmZY7PIA==",
       "dependencies": {
-        "classlist-polyfill": "1.0.3",
+        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -962,9 +962,9 @@
       }
     },
     "node_modules/classlist-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
-      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -5393,11 +5393,11 @@
       }
     },
     "@uswds/uswds": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
-      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.0.tgz",
+      "integrity": "sha512-8mjiP0x0tE5JC7YTuF7WIXkC0pmTVQPzP2CfYE8GHDLdDCnEVUCNjTSljKTqEGxsQuP5JXgNpt99H7pmZY7PIA==",
       "requires": {
-        "classlist-polyfill": "1.0.3",
+        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -5944,9 +5944,9 @@
       }
     },
     "classlist-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
-      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp": "^4.0.2"
   },
   "dependencies": {
-    "@uswds/uswds": "3.4.1"
+    "@uswds/uswds": "3.7.0"
   },
   "overrides": {
     "glob-parent": "6.0.2"


### PR DESCRIPTION
This PR handles security vulnerabilities for November 2023.

- Updated NPM dependencies

**Before**
1 Minor 

**After**
0 vulnerabilities

## Dependencies

Dependency | Old | New
:-- | :-- | :--
@uswds/uswds | 3.4.1 | 3.7.0
## How to test

- Builds run without errors